### PR TITLE
fixed width of layouts, added canteen name

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,8 +2,8 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
+      <module fileurl="file://$PROJECT_DIR$/CaNTU.iml" filepath="$PROJECT_DIR$/CaNTU.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
-      <module fileurl="file://$PROJECT_DIR$/caNTU.iml" filepath="$PROJECT_DIR$/caNTU.iml" />
     </modules>
   </component>
 </project>

--- a/app/src/main/java/com/root/cz3002/cantu/MainActivity.java
+++ b/app/src/main/java/com/root/cz3002/cantu/MainActivity.java
@@ -217,7 +217,6 @@ public class MainActivity extends AppCompatActivity {
         }
 
         String category = v.getTag().toString();
-        Toast.makeText(MainActivity.this, category, Toast.LENGTH_LONG).show();
 
         //dummy, example for populating list
         Stall temp = new Stall(1,"MiniWok","A","Chinese","10:00-20:00");
@@ -236,6 +235,20 @@ public class MainActivity extends AppCompatActivity {
 
         }
       */
+        
+        /////load canteen name
+        LayoutInflater inflater = (LayoutInflater) this.getSystemService(LAYOUT_INFLATER_SERVICE);
+        RelativeLayout bottomBarCanteen = (RelativeLayout) inflater.inflate(R.layout.category_info, (ViewGroup) findViewById(R.id.bottom_bar));
+        TextView categoryInfo = (TextView) bottomBarCanteen.findViewById(R.id.textCategory);
+
+        if(mode.equals("canteen")) {
+            findViewById(R.id.textCategory).setBackgroundResource(R.drawable.rounded_corner_purple);
+            category = "Canteen " + category;
+        }
+
+        categoryInfo.setText(category);
+        ///////////////////////
+
         belongsToCanteenView = v;
     }
 

--- a/app/src/main/java/com/root/cz3002/cantu/OwnerActivity.java
+++ b/app/src/main/java/com/root/cz3002/cantu/OwnerActivity.java
@@ -118,7 +118,7 @@ public class OwnerActivity extends AppCompatActivity {
         for (Order cur: groupOrders)
             addNewItemInList(list, temp);*/
        if (v != null)
-           Toast.makeText(OwnerActivity.this, "Refreshed", Toast.LENGTH_LONG).show();
+           Toast.makeText(OwnerActivity.this, "Refreshed", Toast.LENGTH_SHORT).show();
     }
 
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -9,7 +9,7 @@
     android:orientation="vertical">
     <RelativeLayout
         android:id="@+id/toolbar"
-        android:layout_width="500dp"
+        android:layout_width="360dp"
         android:layout_height="65dp"
         android:orientation="horizontal" />
     <ScrollView

--- a/app/src/main/res/layout/activity_owner.xml
+++ b/app/src/main/res/layout/activity_owner.xml
@@ -4,7 +4,7 @@
     android:background="#ffefef">
     <RelativeLayout
         android:id="@+id/toolbar"
-        android:layout_width="500dp"
+        android:layout_width="360dp"
         android:layout_height="65dp"
         android:background="@android:color/holo_red_light"
         android:alpha="0.8"

--- a/app/src/main/res/layout/category_info.xml
+++ b/app/src/main/res/layout/category_info.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical" android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+
+    <RelativeLayout
+        android:id="@+id/category_info"
+        android:layout_width="match_parent"
+        android:layout_height="50dp"
+        android:gravity="bottom"
+        android:layout_alignParentBottom="true">
+
+        <TextView
+            android:id="@+id/textCategory"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:textSize="30sp"
+            android:textAlignment="center"
+            android:gravity="center_horizontal|center_vertical"
+            android:background="@drawable/rounded_corner_orange"
+            android:text="Category Info" />
+
+    </RelativeLayout>
+
+</RelativeLayout>


### PR DESCRIPTION
Reduced width of layouts to 360dp from 500dp, used RelativeLayout bottomBar for canteen name. @shelinals  Found bug: with or without the new codes, at menu screen -> back button -> return to stall list -> click on transparent bottom bar -> still open stall info